### PR TITLE
Add ability to change pov with mouse without interfering with headtrackr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/nbproject/private/
+nbproject/
+node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = function (grunt) {
+
+    // Load grunt tasks automatically
+    require('load-grunt-tasks')(grunt);
+
+    // Time how long tasks take. Can help when optimizing build times
+    require('time-grunt')(grunt);
+
+    grunt.initConfig({
+        config: {
+            app: '' //root
+        },
+        connect: {
+            options: {
+                port: 9000,
+                livereload: 35729,
+                // Change this to '0.0.0.0' to access the server from outside.
+                hostname: 'localhost'
+            },
+            livereload: {
+                options: {
+                    open: true,
+                    base: '<%= config.app %>'
+                }
+            }
+        },
+        watch: {
+            livereload: {
+                options: {
+                    livereload: '<%= connect.options.livereload %>'
+                },
+                files: [
+                    '<%= config.app %>{,*/}*.html',
+                    '<%= config.app %>css/{,*/}*.css',
+                    '<%= config.app %>js/{,*/}*.js'
+                ]
+            }
+        }
+    });
+
+    grunt.registerTask('serve', [
+        'connect:livereload',
+        'watch'
+    ]);
+
+    grunt.registerTask('default', ['serve']);
+
+    grunt.registerTask('build', function () {
+        grunt.log.error('build task not yet implemented');//only to match yeoman gruntfiles
+    });
+
+};

--- a/js/views/main.js
+++ b/js/views/main.js
@@ -84,14 +84,16 @@
         },
         
         registerPointerManager: function() {
-            //@todo what about mouse outside the window ?
             var that = this;
             this.$el.on('mousedown',function(){
                 that.pointerStateActive = true;
             });
-            this.$el.on('mouseup',function(){
-                that.pointerStateActive = false;
-                that.currentPov = that.panorama.getPov();
+            //needs to be attached to document in case of mouseup triggers outside the original elem
+            $(document).on('mouseup',function(){
+                if(that.pointerStateActive){
+                    that.pointerStateActive = false;
+                    that.currentPov = that.panorama.getPov();
+                }
             });
         },
         

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "author": "Alex J. Hancock <alex@alexhancock.com> (github.com/alexhancock)",
+  "contributors":[
+      "Christophe Rosset <tophe@topheman.com> (github.com/topheman)"
+  ],
   "name": "street-facing",
   "description": "A google streetview app which changes point of view using facetracking",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "repository": {
     "url": ""
   },

--- a/package.json
+++ b/package.json
@@ -10,5 +10,12 @@
     "node": "~0.6.5"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-connect": "^0.9.0",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-open": "^0.2.3",
+    "load-grunt-tasks": "^1.0.0",
+    "time-grunt": "^1.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -29,4 +29,15 @@ var mainView = new Street_Facing_View({
 
 I might spend some time in the near future modularizing and generalizing this code, so people can drop it into any project if there is interest.
 
-** One thing to note when developing locally - Most browsers do not let you use [getUserMedia](http://dev.w3.org/2011/webrtc/editor/getusermedia.html) when serving HTML files directly off the filesystem. It is best to use a simple HTTP server in something like Python or Node to serve the files you're working with.
+### Contributors ###
+
+Run `npm install` , then `grunt` in your terminal, an http server will launch with livereload of the sources to ease your development ([getUserMedia](http://dev.w3.org/2011/webrtc/editor/getusermedia.html) doesn't do so well on `file://` protocol on most browsers)
+
+### Releases notes ###
+
+#### v0.1.0 @topheman
+* Added feature : ability to change pov with mouse without interfering with headtrackr
+* Added Gruntfile to ease dev with local server and livereload
+
+#### v0.0.0 @alexhancock
+* first release by Alex Hancock @alexhancock

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-Street Facing - [Demo](http://alexhancock.github.com/street-facing/)
+Street Facing - [Demo](https://topheman.github.io/street-facing/)
 ==========
 
 ![Street Facing Screenshot](https://dl.dropbox.com/u/12445335/street-facing.png)
 
 **Street Facing** is an experimental application that runs in the browser and allows you to control the POV on Google Street View with movements of your face and head.
 
-You can check out a demo of it [here](http://alexhancock.github.com/street-facing/).
+You can check out a demo of it [here](https://topheman.github.io/street-facing/).
 
 It is built on top of a few things...
 


### PR DESCRIPTION
Hello Alex,

In the past year, I've also myself been playing with headtrackr ( http://dev.topheman.com/parallax-js-with-headtracking-support/ ) and streetview ( http://dev.topheman.com/topheman-street-view/ ), this friday, I passed by the headtrackr repo of @auduno and ended on your demo ... I was having the same idea (but with something in 3d in BabylonJS).

When I tried your demo I felt something was missing, I couldn't change the point of view ... So I coded the feature on top of your app. I didn't touch any part of your code that didn't need to be touch, don't worry.

If you want to test before accepting the PR, it's here : http://topheman.github.io/street-facing/

Tophe

PS : I fixed a bug with the headings (you can now face any angle) - I didn't mention it in the releases notes.
